### PR TITLE
LiveChart no longer auto-scrunches data on the x axis.

### DIFF
--- a/src/pitsoftware/LiveChart.java
+++ b/src/pitsoftware/LiveChart.java
@@ -79,6 +79,16 @@ public class LiveChart extends javax.swing.JFrame implements ChartMouseListener 
         //make sure the size is correct
         chartPanel.setPreferredSize(new java.awt.Dimension(400, 300));
         
+        // make the charts not scrunch up, althought the bounding value probably needs to be adjusted
+        XYPlot xyPlot = chart.getXYPlot();
+        
+        ValueAxis domainAxis = xyPlot.getDomainAxis();
+        domainAxis.setAutoRange(true);
+        domainAxis.setFixedAutoRange(30); // 30 seconds of data at a time
+        
+        ValueAxis rangeAxis = xyPlot.getRangeAxis();
+        rangeAxis.setAutoRange(true);
+        
         //add the mouse listener
         chartPanel.addChartMouseListener(this);
         


### PR DESCRIPTION
The x-axis is set to retain data from the last 30 seconds of input. The y-axis is auto-scaled.